### PR TITLE
ci: add test for msrv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,3 +38,14 @@ jobs:
         run: cargo build
       - name: Run tests
         run: cargo test -v
+
+  msrv:
+    name: Test using MSRV
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - run: rustup toolchain install $(awk '/^rust-version/ { gsub(/"/, ""); print $3 }' Cargo.toml) --profile minimal --no-self-update
+      - run: cargo build --all-targets
+      - run: git submodule update --init
+      - run: cargo test --all-targets

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ description = "A fully YAML 1.2 compliant YAML parser"
 repository = "https://github.com/Ethiraric/yaml-rust2"
 readme = "README.md"
 edition = "2021"
+rust-version = "1.70"
 
 [dependencies]
 arraydeque = "0.5.1"


### PR DESCRIPTION
In Cargo.toml, set rust-version to the current MSRV of 1.70.

Add a ci test to make sure the build and tests pass with the MSRV.